### PR TITLE
Ensure downstream processes run for each query

### DIFF
--- a/workflows/rna_similarity.nf
+++ b/workflows/rna_similarity.nf
@@ -110,5 +110,11 @@ workflow rna_similarity {
         .splitCsv(header: true, sep: ',', strip: true)
         .map { row -> row['id'] }
 
-    PER_QUERY(queries, merged_embeddings, faiss_idx_ch, faiss_map_ch, meta.meta_map)
+    // Convert single-value channels to value channels so they can be reused for each query
+    def embeddings_val = merged_embeddings.first()
+    def faiss_idx_val  = faiss_idx_ch.first()
+    def faiss_map_val  = faiss_map_ch.first()
+    def meta_map_val   = meta.meta_map.first()
+
+    PER_QUERY(queries, embeddings_val, faiss_idx_val, faiss_map_val, meta_map_val)
 }


### PR DESCRIPTION
## Summary
- Convert single-use channels to value channels in `rna_similarity` workflow so downstream processes execute for every query.

## Testing
- `./nextflow run main.nf -profile test -stub-run` *(fails: ginfinity-generate-windows: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad70bcb960832687aa5487bfedbafe