### PR TITLE
Add merged outputs for query results

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,22 +230,27 @@ ls test_results/
 
 ```
 results/
-├── pairs_contigs_report.html                 # Main aggregated report
-├── pairs_contigs_report.unaggregated.html    # Unaggregated report
-├── embeddings.tsv                            # Vector embeddings
-├── distances.sorted.tsv                      # Sorted pairwise distances
-├── pairs_scores_all_contigs.tsv              # All similarity scores
-├── pairs_scores_top_contigs.tsv              # Top N similar pairs
-├── id_meta.tsv                               # Extracted metadata
+├── distances.merged.sorted.tsv                      # Sorted pairwise distances from all queries
+├── pairs_scores_all_contigs.merged.tsv              # All similarity scores across queries
+├── pairs_scores_all_contigs.unaggregated.merged.tsv # Unaggregated scores across queries
+├── embeddings.tsv                                   # Vector embeddings
+├── id_meta.tsv                                      # Extracted metadata
+├── queries_results/                                 # Per-query outputs
+│   └── <query_id>/
+│       ├── distances.sorted.tsv
+│       ├── pairs_scores_all_contigs.tsv
+│       ├── pairs_scores_all_contigs.unaggregated.tsv
+│       ├── pairs_scores_top_contigs.tsv
+│       └── pairs_scores_top_contigs.unaggregated.tsv
 ├── drawings/
-│   ├── contigs/                              # SVG visualizations (aggregated)
-│   └── unagg_windows/                        # SVG visualizations (windowed)
+│   ├── contigs/                                     # SVG visualizations (aggregated)
+│   └── unagg_windows/                               # SVG visualizations (windowed)
 ├── faiss_index/
-│   ├── faiss.index                          # FAISS similarity index
-│   └── faiss_mapping.tsv                    # Index to ID mapping
+│   ├── faiss.index                                 # FAISS similarity index
+│   └── faiss_mapping.tsv                           # Index to ID mapping
 └── plots/
-    ├── distance_distribution.png             # Distance histogram
-    └── score_distribution.png                # Score histogram
+    ├── distance_distribution.png                    # Distance histogram
+    └── score_distribution.png                       # Score histogram
 ```
 
 ## Advanced Usage

--- a/modules/merge_query_results/environment.yml
+++ b/modules/merge_query_results/environment.yml
@@ -1,0 +1,6 @@
+name: merge_query_results
+channels:
+  - conda-forge
+dependencies:
+  - python>=3.8
+  - pandas>=2.2,<3.0

--- a/modules/merge_query_results/main.nf
+++ b/modules/merge_query_results/main.nf
@@ -1,0 +1,44 @@
+#!/usr/bin/env nextflow
+nextflow.enable.dsl=2
+
+process MERGE_QUERY_RESULTS {
+    tag "merge_query_results"
+
+    label 'lightweight'
+
+    publishDir "${params.outdir}", mode: 'copy'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'oras://quay.io/nicoaira/amancevice-pandas-2.2.2:latest' :
+        'amancevice/pandas:2.2.2' }"
+
+    input:
+    path distances
+    path scores_all
+    path scores_unagg
+
+    output:
+    path "distances.merged.sorted.tsv"
+    path "pairs_scores_all_contigs.merged.tsv"
+    path "pairs_scores_all_contigs.unaggregated.merged.tsv"
+
+    script:
+    """
+    python3 - <<'PY'
+import pandas as pd
+
+dist_files = ${groovy.json.JsonOutput.toJson(distances)}
+score_files = ${groovy.json.JsonOutput.toJson(scores_all)}
+unagg_files = ${groovy.json.JsonOutput.toJson(scores_unagg)}
+
+def merge(files, out):
+    dfs = [pd.read_csv(f, sep='\t') for f in files]
+    pd.concat(dfs, ignore_index=True).to_csv(out, sep='\t', index=False)
+
+merge(dist_files, 'distances.merged.sorted.tsv')
+merge(score_files, 'pairs_scores_all_contigs.merged.tsv')
+merge(unagg_files, 'pairs_scores_all_contigs.unaggregated.merged.tsv')
+PY
+    """
+}


### PR DESCRIPTION
## Summary
- merge per-query distances and score TSVs into aggregate files
- expose key outputs from query workflow and merge after all queries
- document new merged files in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad7d3063b88326a3ce58c4c87a771b