### PR TITLE
Fix workflow output references

### DIFF
--- a/workflows/rna_similarity.nf
+++ b/workflows/rna_similarity.nf
@@ -124,8 +124,8 @@ workflow rna_similarity {
     def per_query = PER_QUERY(queries, embeddings_val, faiss_idx_val, faiss_map_val, meta_map_val)
 
     MERGE_QUERY_RESULTS(
-        per_query.out.sorted_distances.collect(),
-        per_query.out.enriched_all.collect(),
-        per_query.out.enriched_unagg.collect()
+        per_query.sorted_distances.collect(),
+        per_query.enriched_all.collect(),
+        per_query.enriched_unagg.collect()
     )
 }


### PR DESCRIPTION
## Summary
- Fix rna_similarity workflow to access subworkflow outputs directly without the `.out` property.

## Testing
- `nextflow run main.nf -profile test,docker,gpu` (fails: `docker: command not found`)
- `nextflow run main.nf -profile test` (fails: `.command.sh: line 3: ginfinity-generate-windows: command not found`)


------
https://chatgpt.com/codex/tasks/task_e_68ad7f08ddb483268ebf572f734a7d20