### PR TITLE
Fix file collision when merging query results

### DIFF
--- a/modules/merge_query_results/main.nf
+++ b/modules/merge_query_results/main.nf
@@ -14,9 +14,9 @@ process MERGE_QUERY_RESULTS {
         'amancevice/pandas:2.2.2' }"
 
     input:
-    path distances
-    path scores_all
-    path scores_unagg
+    path distances,    stageAs: { "${it.parent.name}_${it.name}" }
+    path scores_all,   stageAs: { "${it.parent.name}_${it.name}" }
+    path scores_unagg, stageAs: { "${it.parent.name}_${it.name}" }
 
     output:
     path "distances.merged.sorted.tsv"


### PR DESCRIPTION
## Summary
- Ensure merge_query_results stages inputs with unique filenames to prevent collisions

## Testing
- `./nextflow run main.nf -profile test,conda` *(fails: `conda: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68ad80c27a788326b856a81ebca7b97c