### PR TITLE
Fix stack overflow in MERGE_QUERY_RESULTS

### DIFF
--- a/modules/merge_query_results/main.nf
+++ b/modules/merge_query_results/main.nf
@@ -28,9 +28,9 @@ process MERGE_QUERY_RESULTS {
     python3 - <<'PY'
 import pandas as pd
 
-dist_files = ${groovy.json.JsonOutput.toJson(distances)}
-score_files = ${groovy.json.JsonOutput.toJson(scores_all)}
-unagg_files = ${groovy.json.JsonOutput.toJson(scores_unagg)}
+dist_files = ${groovy.json.JsonOutput.toJson(distances.collect { it.toString() })}
+score_files = ${groovy.json.JsonOutput.toJson(scores_all.collect { it.toString() })}
+unagg_files = ${groovy.json.JsonOutput.toJson(scores_unagg.collect { it.toString() })}
 
 def merge(files, out):
     dfs = [pd.read_csv(f, sep='\t') for f in files]


### PR DESCRIPTION
## Summary
- prevent stack overflow when merging query results by converting `Path` objects to strings before JSON serialization

## Testing
- `./nextflow run main.nf -profile test,docker,gpu` *(fails: docker: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad83f717508326863bb476cd26cb0e