### PR TITLE
feat: add option to skip contig drawings

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,14 @@ The pipeline uses a sophisticated scoring algorithm with several tunable paramet
 | `--gamma` | `0.41` | Combined score weight |
 | `--percentile` | `1` | Top percentile threshold |
 
+### Reporting Parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `--run_aggregated_report` | `true` | Generate aggregated HTML report |
+| `--run_unaggregated_report` | `false` | Generate unaggregated HTML report |
+| `--draw_contig_svgs` | `true` | Draw individual contig SVGs (disables aggregated report when `false`) |
+
 ## Testing
 
 ### Test Dataset

--- a/nextflow.config
+++ b/nextflow.config
@@ -55,6 +55,7 @@ params {
     score_bins                  = 30
 
     // ── Report generation ───────────────────────────────────────────────────
+    draw_contig_svgs            = true
     run_aggregated_report       = true
     run_unaggregated_report     = false
 }

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -31,7 +31,10 @@
     "hist_frac": {"type": "number"},
     "hist_bins": {"type": "integer"},
     "plot_score_distribution": {"type": "boolean"},
-    "score_bins": {"type": "integer"}
+    "score_bins": {"type": "integer"},
+    "run_aggregated_report": {"type": "boolean"},
+    "run_unaggregated_report": {"type": "boolean"},
+    "draw_contig_svgs": {"type": "boolean"}
   },
   "required": ["input", "model_path", "queries"]
 }

--- a/workflows/rna_similarity.nf
+++ b/workflows/rna_similarity.nf
@@ -37,7 +37,7 @@ workflow PER_QUERY {
 
         def filtered = FILTER_TOP_CONTIGS(agg.enriched_all, agg.enriched_unagg, query_id)
 
-        if (params.run_aggregated_report) {
+        if (params.run_aggregated_report && params.draw_contig_svgs) {
             def contigs_draw = DRAW_CONTIG_SVGS(filtered.top_contigs, query_id)
             GENERATE_AGGREGATED_REPORT(filtered.top_contigs, contigs_draw.contig_individual, query_id)
         }


### PR DESCRIPTION
## Summary
- add `draw_contig_svgs` parameter to toggle contig SVG drawing
- gate aggregated report on new parameter
- document reporting options and expose them in schema

## Testing
- `nextflow -version`
- `nextflow run main.nf -profile test -preview --draw_contig_svgs false`

------
https://chatgpt.com/codex/tasks/task_e_68ad83824f5c8326b00813ad89344db6