### PR TITLE
Fix merge result staging and optional query arg

### DIFF
--- a/modules/build_faiss_index/main.nf
+++ b/modules/build_faiss_index/main.nf
@@ -21,13 +21,13 @@ process BUILD_FAISS_INDEX {
     path "faiss_mapping.tsv", emit: faiss_map
 
     script:
+    def query_option = params.query ? "--query ${params.query} \\\n" : ''
     """
-    python3 ${baseDir}/bin/build_faiss_index.py \
-      --input ${embeddings} \
-      --id-column ${params.id_column} \
-      --query ${params.query} \
-      --index-path faiss.index \
-      --mapping-path faiss_mapping.tsv \
+    python3 ${baseDir}/bin/build_faiss_index.py \\
+      --input ${embeddings} \\
+      --id-column ${params.id_column} \\
+      ${query_option}--index-path faiss.index \\
+      --mapping-path faiss_mapping.tsv \\
       --num-workers ${task.cpus}
     """
 }

--- a/modules/merge_query_results/main.nf
+++ b/modules/merge_query_results/main.nf
@@ -14,9 +14,9 @@ process MERGE_QUERY_RESULTS {
         'amancevice/pandas:2.2.2' }"
 
     input:
-    path distances,    stageAs: { "${it.parent.name}_${it.name}" }
-    path scores_all,   stageAs: { "${it.parent.name}_${it.name}" }
-    path scores_unagg, stageAs: { "${it.parent.name}_${it.name}" }
+    path distances
+    path scores_all
+    path scores_unagg
 
     output:
     path "distances.merged.sorted.tsv"


### PR DESCRIPTION
## Summary
- prevent merge_query_results from staging files with shell-expanded names
- make build_faiss_index `--query` argument optional to avoid warnings

## Testing
- `nextflow run main.nf -profile test` *(fails: process not completed; tasks terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68ada23c4af4832680a5d14d3163d115