### PR TITLE
Fix merging of query results

### DIFF
--- a/modules/merge_query_results/main.nf
+++ b/modules/merge_query_results/main.nf
@@ -14,9 +14,14 @@ process MERGE_QUERY_RESULTS {
         'amancevice/pandas:2.2.2' }"
 
     input:
-    path distances,    stageAs: { "${it.parent.name}_${it.name}" }
-    path scores_all,   stageAs: { "${it.parent.name}_${it.name}" }
-    path scores_unagg, stageAs: { "${it.parent.name}_${it.name}" }
+    // Collect all per-query result files as values. Using `val` avoids Nextflow
+    // staging (and renaming) the files in the work directory, which previously
+    // produced bogus temporary names like `Script_***` and caused the process to
+    // fail.  The files remain accessible at their original locations and are
+    // read directly by the Python merging script below.
+    val distances
+    val scores_all
+    val scores_unagg
 
     output:
     path "distances.merged.sorted.tsv"


### PR DESCRIPTION
## Summary
- fix MERGE_QUERY_RESULTS to treat input files as values to avoid missing file staging
- add explanation comment for the merging process

## Testing
- `./nextflow run main.nf -profile test,docker,gpu` *(fails: docker: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ada23c4af4832680a5d14d3163d115