### PR TITLE
feat: auto-generate null scores via shuffled RNAfold

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,13 @@ graph TD
      -profile docker
    ```
 
+   To make scores comparable across queries, specify `--null_shuffles <N>`.
+   For each query, the sequence is shuffled preserving dinucleotides, folded
+   with RNAfold, and scored against the database `N` times using the same
+   query pipeline. These randomized scores form a null distribution that
+   is used to emit `pairs_scores_all_contigs.normalized.tsv` with z-score and
+   p-value columns.
+
 ## Input Format
 
 The pipeline expects a TSV file with the following required columns:
@@ -345,6 +352,7 @@ GINflow consists of 15+ independent Nextflow modules:
 ### Utility Modules
 - **`merge_embeddings`**: Combine embedding batches
 - **`sort_distances`**: Sort similarity results
+- **`normalize_scores`**: Compute z-scores using a provided null distribution
 
 ## Troubleshooting
 

--- a/bin/normalize_scores.py
+++ b/bin/normalize_scores.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+import argparse
+import pandas as pd
+import math
+
+
+def norm_cdf(z: float) -> float:
+    """Cumulative distribution function for standard normal."""
+    return 0.5 * (1.0 + math.erf(z / math.sqrt(2.0)))
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Normalize aggregated scores against a null distribution"
+    )
+    parser.add_argument(
+        "--scores",
+        required=True,
+        help="TSV file with a 'score' column to normalize",
+    )
+    parser.add_argument(
+        "--null-distribution",
+        required=True,
+        help="TSV file containing a 'score' column representing the null distribution",
+    )
+    parser.add_argument(
+        "--output",
+        required=True,
+        help="Output TSV with added z_score and p_value columns",
+    )
+    args = parser.parse_args()
+
+    scores_df = pd.read_csv(args.scores, sep="\t")
+    null_df = pd.read_csv(args.null_distribution, sep="\t")
+
+    if "score" not in scores_df.columns:
+        raise ValueError("scores file must contain a 'score' column")
+    if "score" not in null_df.columns:
+        raise ValueError("null distribution file must contain a 'score' column")
+
+    mu = null_df["score"].mean()
+    sigma = null_df["score"].std(ddof=0)
+    if sigma == 0:
+        raise ValueError("null distribution standard deviation is zero")
+
+    z = (scores_df["score"] - mu) / sigma
+    scores_df["z_score"] = z
+    scores_df["p_value"] = 1.0 - z.map(norm_cdf)
+
+    scores_df.to_csv(args.output, sep="\t", index=False)
+    print(f"Written normalized scores to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/shuffle_and_fold.py
+++ b/bin/shuffle_and_fold.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+import argparse, random, subprocess, pandas as pd
+from collections import defaultdict
+
+def dinuc_shuffle(seq: str) -> str:
+    if len(seq) < 2:
+        return seq
+    edges = defaultdict(list)
+    for a, b in zip(seq[:-1], seq[1:]):
+        edges[a].append(b)
+    for k in edges:
+        random.shuffle(edges[k])
+    start = seq[0]
+    path = [start]
+    out = []
+    while path:
+        v = path[-1]
+        if edges[v]:
+            path.append(edges[v].pop())
+        else:
+            out.append(path.pop())
+    shuffled = ''.join(out[::-1])
+    if len(shuffled) != len(seq):
+        return dinuc_shuffle(seq)
+    return shuffled
+
+def main():
+    ap = argparse.ArgumentParser(description="Shuffle sequence dinucleotides and fold with RNAfold")
+    ap.add_argument('--meta', required=True, help='id_meta TSV with sequences')
+    ap.add_argument('--id-column', required=True, help='ID column name')
+    ap.add_argument('--query', required=True, help='Query ID to shuffle')
+    ap.add_argument('--new-id', required=True, help='ID to assign to shuffled sequence')
+    ap.add_argument('--output', required=True, help='Output TSV path')
+    args = ap.parse_args()
+
+    df = pd.read_csv(args.meta, sep='\t', dtype=str)
+    row = df[df[args.id_column] == args.query]
+    if row.empty:
+        raise SystemExit(f"ID {args.query} not found in meta file")
+    seq_col = [c for c in row.columns if 'sequence' in c.lower()]
+    if not seq_col:
+        raise SystemExit('No sequence column found in meta file')
+    seq = row.iloc[0][seq_col[0]]
+    shuffled = dinuc_shuffle(seq)
+
+    proc = subprocess.run(['RNAfold', '--noPS'], input=(shuffled+'\n').encode(), stdout=subprocess.PIPE, check=True)
+    lines = proc.stdout.decode().strip().splitlines()
+    if len(lines) < 2:
+        raise SystemExit('RNAfold produced unexpected output')
+    structure = lines[1].split()[0]
+    L = len(shuffled)
+
+    with open(args.output, 'w') as fh:
+        fh.write(f"{args.id_column}\tsequence\tsecondary_structure\twindow_start\twindow_end\tseq_len\n")
+        fh.write(f"{args.new_id}\t{shuffled}\t{structure}\t0\t{L}\t{L}\n")
+
+if __name__ == '__main__':
+    main()

--- a/containers/Dockerfile.shuffle_and_fold
+++ b/containers/Dockerfile.shuffle_and_fold
@@ -1,0 +1,10 @@
+FROM continuumio/miniconda3:latest
+
+COPY modules/shuffle_and_fold/environment.yml /tmp/environment.yml
+RUN conda env create -f /tmp/environment.yml && \
+    conda clean -afy
+ENV PATH /opt/conda/envs/shuffle_and_fold/bin:$PATH
+
+WORKDIR /app
+COPY bin/ bin/
+RUN chmod +x bin/shuffle_and_fold.py

--- a/modules/aggregate_score_raw/environment.yml
+++ b/modules/aggregate_score_raw/environment.yml
@@ -1,0 +1,8 @@
+name: aggregate_score_raw
+channels:
+  - conda-forge
+dependencies:
+  - python>=3.8
+  - pandas>=2.2,<3.0
+  - numpy>=1.26,<3.0
+  - dask>=2024.1.0

--- a/modules/aggregate_score_raw/main.nf
+++ b/modules/aggregate_score_raw/main.nf
@@ -1,0 +1,31 @@
+#!/usr/bin/env nextflow
+nextflow.enable.dsl=2
+
+process AGGREGATE_SCORE_RAW {
+    tag { "aggregate_score_raw_${query_id}" }
+
+    label 'lightweight'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'oras://quay.io/nicoaira/ginflow-aggregate-score:latest' :
+        'nicoaira/ginflow-aggregate-score:latest' }"
+
+    input:
+    tuple val(query_id), path(sorted_distances)
+
+    output:
+    tuple val(query_id), path('scores.tsv'), emit: scores
+
+    script:
+    """
+    python3 ${baseDir}/bin/aggregated_score.py \
+      --input ${sorted_distances} \
+      --id-column ${params.id_column} \
+      --alpha1 ${params.alpha1} --alpha2 ${params.alpha2} \
+      --beta1 ${params.beta1}   --beta2 ${params.beta2} \
+      --gamma ${params.gamma}   --percentile ${params.percentile} \
+      --mode contigs \
+      --output scores.tsv
+    """
+}

--- a/modules/merge_query_results/main.nf
+++ b/modules/merge_query_results/main.nf
@@ -24,9 +24,9 @@ process MERGE_QUERY_RESULTS {
     val scores_unagg
 
     output:
-    path "distances.merged.sorted.tsv"
-    path "pairs_scores_all_contigs.merged.tsv"
-    path "pairs_scores_all_contigs.unaggregated.merged.tsv"
+    path "distances.merged.sorted.tsv",                  emit: distances
+    path "pairs_scores_all_contigs.merged.tsv",          emit: scores
+    path "pairs_scores_all_contigs.unaggregated.merged.tsv", emit: scores_unagg
 
     script:
     """

--- a/modules/normalize_scores/environment.yml
+++ b/modules/normalize_scores/environment.yml
@@ -1,0 +1,6 @@
+name: normalize_scores
+channels:
+  - conda-forge
+dependencies:
+  - python>=3.8
+  - pandas>=2.2,<3.0

--- a/modules/normalize_scores/main.nf
+++ b/modules/normalize_scores/main.nf
@@ -1,0 +1,30 @@
+#!/usr/bin/env nextflow
+nextflow.enable.dsl=2
+
+process NORMALIZE_SCORES {
+    tag "normalize_scores"
+
+    label 'lightweight'
+
+    publishDir "${params.outdir}", mode: 'copy'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'oras://quay.io/nicoaira/amancevice-pandas-2.2.2:latest' :
+        'amancevice/pandas:2.2.2' }"
+
+    input:
+    path scores
+    path null_dist
+
+    output:
+    path "pairs_scores_all_contigs.normalized.tsv"
+
+    script:
+    """
+    python3 ${baseDir}/bin/normalize_scores.py \
+      --scores $scores \
+      --null-distribution $null_dist \
+      --output pairs_scores_all_contigs.normalized.tsv
+    """
+}

--- a/modules/shuffle_and_fold/environment.yml
+++ b/modules/shuffle_and_fold/environment.yml
@@ -1,0 +1,8 @@
+name: shuffle_and_fold
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - python=3.10
+  - pandas
+  - viennarna

--- a/modules/shuffle_and_fold/main.nf
+++ b/modules/shuffle_and_fold/main.nf
@@ -1,0 +1,30 @@
+#!/usr/bin/env nextflow
+nextflow.enable.dsl=2
+
+process SHUFFLE_AND_FOLD {
+    tag { "shuffle_and_fold_${orig_id}" }
+
+    label 'lightweight'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'oras://quay.io/nicoaira/viennarna:latest' :
+        'nicoaira/viennarna:latest' }"
+
+    input:
+    tuple val(orig_id), val(new_id)
+    path meta_map
+
+    output:
+    path "${new_id}.tsv", emit: shuffled
+
+    script:
+    """
+    python3 ${baseDir}/bin/shuffle_and_fold.py \
+      --meta ${meta_map} \
+      --id-column ${params.id_column} \
+      --query ${orig_id} \
+      --new-id ${new_id} \
+      --output ${new_id}.tsv
+    """
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -46,6 +46,11 @@ params {
     gamma                       = 0.41
     percentile                  = 1
 
+    // Number of dinucleotide shuffles per query to build an automatic null
+    // distribution. When > 0, random sequences are generated and folded
+    // internally to produce baseline scores.
+    null_shuffles               = 0
+
     // ── Plotting ────────────────────────────────────────────────────────────
     plot_distances_distribution = true
     hist_seed                   = 42


### PR DESCRIPTION
## Summary
- remove external `--null_scores` input
- route dinucleotide-shuffled queries through FAISS and scoring to build null distributions
- normalize real query scores against the shuffled baseline

## Testing
- `nextflow run main.nf -profile test` *(ginfinity-generate-windows: command not found)*
- `nextflow run main.nf -profile test,docker` *(docker: command not found)*
- `nextflow run main.nf -profile test,conda` *(conda: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af56e1a7a48326b370f0f70b8332f5